### PR TITLE
custom importer

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -8,7 +8,7 @@
     "prebuild": "npm run clean:dist -s",
     "build": "npm run build:scripts && npm run build:styles",
     "build:scripts": "babel src --out-dir dist",
-    "build:styles": "node-sass src/index.scss dist/<%= component_name %>.css",
+    "build:styles": "node-sass src/index.scss dist/<%= component_name %>.css --importer ./importer",
     "postbuild:styles": "cp dist/<%= component_name %>.css dist/_<%= component_name %>.scss",
     "postinstall": "npm run build",
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -8,7 +8,7 @@
     "prebuild": "npm run clean:dist -s",
     "build": "npm run build:scripts && npm run build:styles",
     "build:scripts": "babel src --out-dir dist",
-    "build:styles": "node-sass src/index.scss dist/<%= component_name %>.css --importer ./importer",
+    "build:styles": "node-sass src/index.scss dist/<%= component_name %>.css --importer ./scripts/importer.js",
     "postbuild:styles": "cp dist/<%= component_name %>.css dist/_<%= component_name %>.scss",
     "postinstall": "npm run build",
 

--- a/app/templates/importer/index.js
+++ b/app/templates/importer/index.js
@@ -1,0 +1,19 @@
+var path = require('path');
+var fs = require('fs');
+var control = 0;
+module.exports = function (url, file, done) {
+  recursiveFind(url, file, done);
+}
+
+function recursiveFind(url, file, done){
+  control ++;
+  if (control == 10)
+    return;
+
+  fs.access(path.join(__dirname, '../src', url), fs.R_OK, function(err){
+    if (err) {
+      return recursiveFind(path.join('../', url), file, done);
+    }
+    done({ file: url });
+  });
+}

--- a/app/templates/importer/index.js
+++ b/app/templates/importer/index.js
@@ -1,19 +1,22 @@
 var path = require('path');
 var fs = require('fs');
-var control = 0;
+
 module.exports = function (url, file, done) {
-  recursiveFind(url, file, done);
+  if(url.indexOf('@schibstedspain/') !== -1){
+    done({ file: recursiveFind(url)});
+  } else {
+    return done({file: url});
+  }
 }
 
-function recursiveFind(url, file, done){
-  control ++;
-  if (control == 10)
-    return;
+function recursiveFind(url){
+  const urlTree = url.split(path.sep);
+  urlTree.pop();
+  const folder = path.join(__dirname, '../node_modules', urlTree.join(path.sep));
 
-  fs.access(path.join(__dirname, '../src', url), fs.R_OK, function(err){
-    if (err) {
-      return recursiveFind(path.join('../', url), file, done);
-    }
-    done({ file: url });
-  });
+  if(!fs.existsSync(folder)) {
+    return recursiveFind(path.join('../', url));
+  } else {
+    return url;
+  }
 }

--- a/app/templates/scripts/_importer.js
+++ b/app/templates/scripts/_importer.js
@@ -2,10 +2,10 @@ var path = require('path');
 var fs = require('fs');
 
 module.exports = function (url, file, done) {
-  if(url.indexOf('@schibstedspain/') !== -1){
-    done({ file: recursiveFind(url)});
-  } else {
+  if(url[0] === '.'){
     return done({file: url});
+  } else {
+    done({ file: recursiveFind(url)});
   }
 }
 
@@ -13,6 +13,11 @@ function recursiveFind(url){
   const urlTree = url.split(path.sep);
   urlTree.pop();
   const folder = path.join(__dirname, '../node_modules', urlTree.join(path.sep));
+
+  if(folder === path.join(path.sep + urlTree.join(path.sep)))
+  {
+    return '';
+  }
 
   if(!fs.existsSync(folder)) {
     return recursiveFind(path.join('../', url));

--- a/app/templates/src/_index.scss
+++ b/app/templates/src/_index.scss
@@ -1,2 +1,2 @@
-@import '../node_modules/@schibstedspain/theme-sui/src/settings';
-@import './<%= component_name %>/<%= component_name %>';
+@import '@schibstedspain/theme-sui/src/_settings.scss';
+@import './<%= component_name %>/_<%= component_name %>.scss';

--- a/app/templates/src/_index.scss
+++ b/app/templates/src/_index.scss
@@ -1,2 +1,2 @@
-@import '@schibstedspain/theme-sui/src/_settings.scss';
-@import './<%= component_name %>/_<%= component_name %>.scss';
+@import '@schibstedspain/theme-sui/src/settings';
+@import './<%= component_name %>/<%= component_name %>';


### PR DESCRIPTION
Proposed workaround for solving the .scss problem when importing from a node package. It uses a new feature of the latest version of node_sass: custom importer.

I've tried a first approach of a custom importer and it works, recursively searching for a file in parent directories.

Things I don't like of this approach:
* recursivity
* we loose automatic partial loading, we have to put underscore and .scss extension. This is because in each iteration, the custom importer checks if the file exists in the path.

It can be improved. 